### PR TITLE
Bugfix for test_batch_norm_op_v2

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
@@ -210,7 +210,12 @@ class TestBatchNormChannelLast(unittest.TestCase):
                 channel_first_x = paddle.transpose(x, [0, 3, 1, 2])
                 y2 = net2(channel_first_x)
                 y2 = paddle.transpose(y2, [0, 2, 3, 1])
-                self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
+                if core.is_compiled_with_rocm():
+                    self.assertEqual(
+                        np.allclose(
+                            y1.numpy(), y2.numpy(), atol=1e-06), True)
+                else:
+                    self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
 
     def test_3d(self):
         for p in self.places:
@@ -224,7 +229,12 @@ class TestBatchNormChannelLast(unittest.TestCase):
                 channel_first_x = paddle.transpose(x, [0, 4, 1, 2, 3])
                 y2 = net2(channel_first_x)
                 y2 = paddle.transpose(y2, [0, 2, 3, 4, 1])
-                self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
+                if core.is_compiled_with_rocm():
+                    self.assertEqual(
+                        np.allclose(
+                            y1.numpy(), y2.numpy(), atol=1e-06), True)
+                else:
+                    self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
 
 
 class TestBatchNormUseGlobalStats(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
@@ -213,7 +213,7 @@ class TestBatchNormChannelLast(unittest.TestCase):
                 if core.is_compiled_with_rocm():
                     self.assertEqual(
                         np.allclose(
-                            y1.numpy(), y2.numpy(), atol=1e-06), True)
+                            y1.numpy(), y2.numpy(), atol=1e-07), True)
                 else:
                     self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
 
@@ -232,7 +232,7 @@ class TestBatchNormChannelLast(unittest.TestCase):
                 if core.is_compiled_with_rocm():
                     self.assertEqual(
                         np.allclose(
-                            y1.numpy(), y2.numpy(), atol=1e-06), True)
+                            y1.numpy(), y2.numpy(), atol=1e-07), True)
                 else:
                     self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
 

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
@@ -171,7 +171,10 @@ class TestBatchNorm(unittest.TestCase):
 class TestBatchNormChannelLast(unittest.TestCase):
     def setUp(self):
         self.original_dtyep = paddle.get_default_dtype()
-        paddle.set_default_dtype("float64")
+        if core.is_compiled_with_rocm():
+            paddle.set_default_dtype("float32")
+        else:
+            paddle.set_default_dtype("float64")
         self.places = [fluid.CPUPlace()]
         if core.is_compiled_with_cuda() and core.op_support_gpu("batch_norm"):
             self.places.append(fluid.CUDAPlace(0))

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
@@ -134,6 +134,7 @@ class TestBatchNorm(unittest.TestCase):
             self.assertTrue(np.allclose(y3, y4))
 
     def test_static(self):
+        paddle.enable_static()
         places = [fluid.CPUPlace()]
         if core.is_compiled_with_cuda() and core.op_support_gpu("batch_norm"):
             places.append(fluid.CUDAPlace(0))
@@ -166,6 +167,7 @@ class TestBatchNorm(unittest.TestCase):
             y1 = compute_v1(x, False, False)
             y2 = compute_v2(x)
             self.assertTrue(np.allclose(y1, y2))
+        paddle.disable_static()
 
 
 class TestBatchNormChannelLast(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复 ROCm 不支持 double 类型，但还是存在随机挂现象

- 单元测试通过
```
$ cd Paddle/build_rocm35
$ python ../python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
/public/home/windstamp/.local/lib/python3.8/site-packages/paddle/fluid/layers/utils.py:26: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  def convert_to_list(value, n, name, dtype=np.int):
/public/home/windstamp/.local/lib/python3.8/site-packages/paddle/nn/layer/norm.py:647: UserWarning: When training, we now always track global mean and variance.
  warnings.warn(
W0202 17:11:19.782588 24646 device_context.cc:362] Please NOTE: device: 0, GPU Compute Capability: 90.6, Driver API Version: 313.0, Runtime API Version: 3.3
W0202 17:11:20.078001 24646 device_context.cc:376] device: 0, MIOpen Version: 2.4.0
...........
----------------------------------------------------------------------
Ran 11 tests in 1.874s

OK
```

- 单元测试出现随机挂
```
$ cd Paddle/build_rocm35
$ python ../python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py
/public/home/windstamp/.local/lib/python3.8/site-packages/paddle/fluid/layers/utils.py:26: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  def convert_to_list(value, n, name, dtype=np.int):
/public/home/windstamp/.local/lib/python3.8/site-packages/paddle/nn/layer/norm.py:647: UserWarning: When training, we now always track global mean and variance.
  warnings.warn(
W0202 17:10:56.610620 24515 device_context.cc:362] Please NOTE: device: 0, GPU Compute Capability: 90.6, Driver API Version: 313.0, Runtime API Version: 3.3
W0202 17:10:56.916939 24515 device_context.cc:376] device: 0, MIOpen Version: 2.4.0
.....FF....
======================================================================
FAIL: test_2d (__main__.TestBatchNormChannelLast)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py", line 213, in test_2d
    self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
AssertionError: False != True

======================================================================
FAIL: test_3d (__main__.TestBatchNormChannelLast)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../python/paddle/fluid/tests/unittests/test_batch_norm_op_v2.py", line 227, in test_3d
    self.assertEqual(np.allclose(y1.numpy(), y2.numpy()), True)
AssertionError: False != True

----------------------------------------------------------------------
Ran 11 tests in 2.145s
```
